### PR TITLE
Add infrastructure-as-code security prompts (Terraform / CloudFormation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,29 @@ This repository contains a broadly compatible set of baseline rules, encoding se
 
 ## What's Inside This Repository?
 
-- `generate_rules.py`: The Python script responsible for generating these rules files, leveraging the `gemini-2.5-flash-preview-05-20` model
+- `generate_rules.py`: The Python script responsible for generating these rules files, leveraging the `gemini-2.5-flash-preview-05-20` model (requires `GOOGLE_API_KEY` environment variable)
 - `prompt.md`: A transparent look at the core prompt used to guide Gemini in crafting these rules files
 - **Rules Directory**: The heart of the repository, organized intuitively by Programming Language/Framework to provide easy access to the relevant security rules.
+
+## Using the Rule Generator
+
+To use the `generate_rules.py` script to create your own rules files:
+
+1. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Set up Google API Key:**
+   ```bash
+   export GOOGLE_API_KEY="your-google-api-key-here"
+   ```
+   You can obtain a Google API key from the [Google AI Studio](https://aistudio.google.com/app/apikey).
+
+3. **Run the generator:**
+   ```bash
+   python generate_rules.py
+   ```
 
 ### Supported Technologies
 

--- a/README.md
+++ b/README.md
@@ -17,26 +17,6 @@ This repository contains a broadly compatible set of baseline rules, encoding se
 - `prompt.md`: A transparent look at the core prompt used to guide Gemini in crafting these rules files
 - **Rules Directory**: The heart of the repository, organized intuitively by Programming Language/Framework to provide easy access to the relevant security rules.
 
-## Using the Rule Generator
-
-To use the `generate_rules.py` script to create your own rules files:
-
-1. **Install dependencies:**
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-2. **Set up Google API Key:**
-   ```bash
-   export GOOGLE_API_KEY="your-google-api-key-here"
-   ```
-   You can obtain a Google API key from the [Google AI Studio](https://aistudio.google.com/app/apikey).
-
-3. **Run the generator:**
-   ```bash
-   python generate_rules.py
-   ```
-
 ### Supported Technologies
 
 > [!IMPORTANT]

--- a/generate_rules.py
+++ b/generate_rules.py
@@ -11,6 +11,10 @@ def generate_secure_rules_prompt(language: str, assistant: str, framework: str=N
         assistant: The coding assistant to target, defaults to Cline
         framework: The core relevant framework, defaults to None
     """
+    
+    # Define infrastructure languages that need different security focus
+    infrastructure_languages = ['hcl', 'yaml']
+    is_infrastructure = language.lower() in infrastructure_languages
 
     ruleformat = 'The rules file must be formatted as a well-formed Markdown file.'
 
@@ -37,6 +41,41 @@ globs: **/*.js, **/*.ts # File patterns this rule applies to
 ```\n'''
 
 
+    if is_infrastructure:
+        return '''You are an expert DevSecOps engineer specializing in secure infrastructure-as-code generation using LLMs. Your task is to generate a comprehensive {0} rules file, specifically designed to enforce security best practices for {1} infrastructure configurations using {2}.
+
+{3}
+Adhere to best practices for effective rules files: they should be specific, actionable, concise, and maintain a consistent format.
+
+## Begin the rules file with the following foundational instructions for the LLM:
+- As a security-aware infrastructure engineer, generate secure {1} configurations using {2} that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+- Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+- Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+- Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+- **Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+## Identify and Address Top Infrastructure Security Risks for {1} + {2}:
+Based on common cloud security misconfigurations impacting {1} and {2} infrastructure across cloud providers, identify the top 7-10 relevant security risks. For each identified risk, include the following in the rules file:
+
+1. Risk Category: Clearly state the security risk category (e.g., "Excessive Permissions", "Unencrypted Storage", "Public Access", "Network Exposure").
+2. Summary: Provide a concise, one-sentence summary of the security risk and its potential impact across cloud platforms.
+3. Mitigation Rule ({1}/{2} Specific): Formulate a concrete, actionable rule for the LLM to follow, directly addressing the risk within the context of {1} and {2}. When possible, reference cloud-agnostic best practices and include guidance for major cloud providers (AWS, Azure, GCP).
+
+Example format:
+
+    ### Risk: Risk Category Name
+    **Summary:** Risk description and potential impact across cloud platforms
+    **Mitigation Rule:** Prescriptive, {2}-specific guidance for secure configuration that considers multi-cloud scenarios
+
+## Formatting and Content Constraints:
+
+* **No Examples**: Do not include any code examples within the rules file. The rules should be purely prescriptive guidance.
+* **Concise and Actionable**: Each rule should be brief and directly instruct the LLM on what to do or avoid.
+* **Structured**: The rules file should be logically structured, with clear headings or markers for each security risk.
+* **Return Only Rules File**: Your response should only be the generated {0} rules file, properly formatted, and nothing else. Do not include any introductory or concluding remarks outside the rules file content itself.
+'''.format(assistant,language,framework,ruleformat)
+
+    # Application security prompt for traditional programming languages
     return '''You are an expert software engineer specializing in secure code generation using LLMs. Your task is to generate a comprehensive {0} rules file, specifically designed to enforce security best practices for {1} applications built with {2}.
 
 {3}

--- a/hcl/terraform/.clinerules
+++ b/hcl/terraform/.clinerules
@@ -1,0 +1,51 @@
+# Secure HCL Configuration Rules for LLM Generation
+
+## Foundational Instructions for Secure Infrastructure Generation
+
+As a security-aware infrastructure engineer, generate secure HCL configurations using Terraform that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others). Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+
+*   Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+*   Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+*   **Avoid Hardcoded Values**: Never hardcode sensitive values like passwords, API keys, cryptographic keys, or private SSH keys directly in Terraform configurations or variable files. Always use external secret management services appropriate for the target cloud platform (e.g., AWS Secrets Manager, Azure Key Vault, Google Secret Manager, HashiCorp Vault). Reference secrets dynamically at runtime.
+
+## Top Infrastructure Security Risks and Mitigation Rules (HCL + Terraform Specific)
+
+### Risk: Excessive Permissions / Least Privilege Violation
+**Summary:** Granting overly broad or unnecessary permissions to IAM roles, service accounts, or resources can lead to privilege escalation and unauthorized access if compromised.
+**Mitigation Rule:** Always define IAM policies and roles with the absolute minimum permissions required for a resource or identity to perform its intended function, following the principle of least privilege. Explicitly deny actions rather than implicitly allowing broad access, and avoid `*` actions where possible. Review and restrict `iam:PassRole` permissions.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption at rest in storage services (e.g., object storage, databases, block storage) makes it vulnerable to unauthorized access upon breach.
+**Mitigation Rule:** Mandate server-side encryption by default for all data at rest in storage services (e.g., S3 buckets, Azure Storage Accounts, GCP Cloud Storage buckets, EBS volumes, Azure Disks, GCP Persistent Disks, managed databases). Prefer customer-managed keys (CMK) via KMS/Key Vault where compliance requires it, otherwise use service-managed keys.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Exposing sensitive services or data to the public internet without proper authentication, authorization, or business justification creates a significant attack surface.
+**Mitigation Rule:** Restrict public network access to all infrastructure resources (e.g., storage buckets, databases, compute instances, load balancers, APIs) unless absolutely necessary and explicitly approved. If public access is required, implement strict ingress rules, WAFs, and robust authentication/authorization mechanisms. Block public access to S3 buckets and similar object storage by default.
+
+### Risk: Insecure Network Configuration and Segmentation
+**Summary:** Weak or misconfigured network security groups, firewalls, and network ACLs can lead to unauthorized network access, lateral movement, and data exfiltration.
+**Mitigation Rule:** Implement strict network segmentation using VPCs/VNets/private subnets, security groups, network ACLs, and firewall rules to control traffic flow. Define explicit ingress and egress rules that permit only necessary ports and IP ranges. Avoid allowing `0.0.0.0/0` on sensitive ports (e.g., SSH, RDP, database ports) or on production resources.
+
+### Risk: Missing or Inadequate Logging and Monitoring
+**Summary:** A lack of comprehensive audit trails and monitoring capabilities prevents effective detection of security incidents, unauthorized activities, and compliance violations.
+**Mitigation Rule:** Enable extensive logging for all cloud services, including API activity (e.g., CloudTrail, Azure Activity Log, Cloud Audit Logs), resource configuration changes, network flow logs, and application logs. Configure log retention policies, centralize logs to a secure location, and integrate with security information and event management (SIEM) solutions for real-time monitoring and alerting.
+
+### Risk: Hardcoded Sensitive Information
+**Summary:** Embedding sensitive credentials, API keys, or secrets directly in configuration files or code exposes them to source control compromise and unauthorized access.
+**Mitigation Rule:** Never hardcode any sensitive values. Always retrieve secrets from dedicated cloud-native secret management services (e.g., AWS Secrets Manager, Azure Key Vault, Google Secret Manager) or HashiCorp Vault during runtime. Ensure that secret management configurations follow least privilege and are themselves securely configured.
+
+### Risk: Unsecured Compute Configurations
+**Summary:** Deploying compute instances (VMs, containers, serverless functions) without hardened images, proper patch management, or host-level security controls increases vulnerability to exploits.
+**Mitigation Rule:** Utilize hardened operating system images or container images for compute resources, preferably from trusted sources or custom-built with security baselines. Provision compute with minimal required software. Apply security groups/firewall rules at the instance level. Do not provision instances with default administrative user accounts.
+
+### Risk: Vulnerable Database Configurations
+**Summary:** Misconfigured databases, such as those exposed publicly, lacking encryption, or using weak authentication, are prime targets for data breaches.
+**Mitigation Rule:** Configure databases securely: deploy them in private subnets, restrict access to specific applications or subnets, enable encryption for data at rest and in transit, and enforce strong authentication mechanisms (e.g., IAM authentication, strong passwords, multi-factor authentication where applicable). Disable unnecessary public endpoints.
+
+### Risk: Weak Key Management
+**Summary:** Inadequate management of cryptographic keys can compromise the security of encrypted data, leading to data exposure if keys are stolen or misused.
+**Mitigation Rule:** Mandate the use of cloud-native Key Management Services (KMS) like AWS KMS, Azure Key Vault, or Google Cloud KMS for generating, storing, and managing all cryptographic keys used for encryption, digital signatures, and authentication. Define explicit key usage policies and enforce least privilege for key access.
+
+### Risk: Lack of Resource Deletion Protection
+**Summary:** Accidental or malicious deletion of critical infrastructure resources can lead to significant downtime, data loss, and operational disruption.
+**Mitigation Rule:** Enable deletion protection, termination protection, or resource locks for critical production infrastructure components (e.g., databases, primary storage, production compute instances, network components) where supported by the cloud provider. Ensure Terraform configurations leverage these features to prevent unintended destruction.

--- a/hcl/terraform/.windsurfrules
+++ b/hcl/terraform/.windsurfrules
@@ -1,0 +1,44 @@
+---
+trigger: glob
+description: Enforces secure best practices for HCL infrastructure configurations using Terraform.
+globs: **/*.tf, **/*.tfvars, **/*.hcl
+---
+- As a security-aware infrastructure engineer, generate secure HCL configurations using Terraform that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+- Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+- Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+- Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+- **Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+## Identify and Address Top Infrastructure Security Risks for HCL + Terraform:
+
+### Risk: Excessive Permissions (Least Privilege)
+**Summary:** Granting more permissions than necessary to identities (users, roles, service accounts) increases the attack surface and potential for unauthorized access or data breaches across all cloud providers.
+**Mitigation Rule:** Always apply the principle of least privilege, granting only the minimum necessary permissions for any identity or resource. Restrict IAM policies (AWS), roles (Azure), or service account permissions (GCP) to specific actions on specific resources, avoiding wildcards (`*`) wherever possible in permissions.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption at rest exposes information to unauthorized access if storage resources are compromised, a critical risk across all cloud data stores.
+**Mitigation Rule:** Enforce encryption at rest for all storage services (e.g., AWS S3, Azure Blob Storage, GCP Cloud Storage buckets, databases, disks) using managed encryption keys (CMK/KMS) or platform-managed keys by default.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Exposing resources like storage buckets, databases, or virtual machines directly to the public internet without proper authentication or access controls leads to data leakage or unauthorized access.
+**Mitigation Rule:** Prevent public read/write access to storage buckets. Configure network security groups (Azure), security groups (AWS), or firewall rules (GCP) to block direct public internet access to databases, internal services, and compute instances unless absolutely necessary and with strictly defined, minimal ingress rules.
+
+### Risk: Overly Permissive Network Access
+**Summary:** Configuring network security rules (e.g., security groups, NSGs, firewall rules) with broad inbound or outbound access (`0.0.0.0/0`) allows unrestricted communication, significantly increasing the risk of network-based attacks across all cloud networks.
+**Mitigation Rule:** Restrict network ingress and egress rules to only the necessary IP addresses, CIDR blocks, ports, and protocols. Avoid `0.0.0.0/0` for inbound rules on anything other than public-facing load balancers that are protected by a Web Application Firewall (WAF) or equivalent.
+
+### Risk: Missing or Inadequate Logging and Monitoring
+**Summary:** Insufficient logging of API calls, resource changes, and network activity hinders the ability to detect and respond to security incidents, making forensics and compliance difficult across all cloud environments.
+**Mitigation Rule:** Enable comprehensive logging (e.g., AWS CloudTrail, Azure Activity Log/Monitor, GCP Cloud Audit Logs) for all management plane and data plane activities. Integrate logs with centralized monitoring and alerting systems for security events.
+
+### Risk: Hardcoded Secrets and Sensitive Data
+**Summary:** Embedding sensitive information such as API keys, database credentials, or private keys directly within HCL code or variables poses a severe security risk as it can be exposed if the code repository is compromised.
+**Mitigation Rule:** Never hardcode sensitive values directly in Terraform configurations or variables. Instead, use cloud-native secret management services (e.g., AWS Secrets Manager, Azure Key Vault, GCP Secret Manager) to securely store and retrieve credentials at runtime.
+
+### Risk: Insecure Default Service Configurations
+**Summary:** Many cloud services default to less secure settings for ease of use (e.g., unencrypted traffic, public endpoints), which, if not explicitly overridden in Terraform, can introduce significant vulnerabilities.
+**Mitigation Rule:** Always explicitly define secure configurations for all provisioned services, overriding insecure defaults. This includes enforcing HTTPS for web services, disabling unnecessary features, and enabling encryption and access controls.
+
+### Risk: Vulnerable Compute Environment Configurations
+**Summary:** Deploying compute resources (VMs, containers, serverless functions) using outdated operating systems, runtimes, or unhardened base images can expose applications to known vulnerabilities and increase the attack surface.
+**Mitigation Rule:** Specify secure and current operating system images, container images, or serverless function runtimes. Ensure that compute environments are configured with minimal necessary software, apply host-based firewalls, and are hardened according to security baselines.

--- a/hcl/terraform/AGENTS.md
+++ b/hcl/terraform/AGENTS.md
@@ -1,0 +1,43 @@
+As a security-aware infrastructure engineer, generate secure HCL configurations using Terraform that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+**Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+---
+
+### Risk: Excessive Permissions
+**Summary:** Granting overly broad or unnecessary permissions to identities and resources increases the blast radius of a compromise across all cloud environments.
+**Mitigation Rule:** Configure IAM roles, service principals, and identity policies with the absolute minimum necessary permissions (least privilege). Use fine-grained actions and resource constraints. Avoid `*` in actions and resources unless absolutely justified and documented with security implications.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption in object storage, databases, or disk volumes poses a significant risk of data exfiltration or compromise if breached.
+**Mitigation Rule:** Ensure all data storage resources (e.g., S3 buckets, Azure storage accounts, GCP Cloud Storage buckets, databases, EBS volumes, managed disks) are configured with encryption at rest, preferably using customer-managed keys (CMK) or provider-managed keys (PMK) where CMK is not feasible. Enforce encryption for all new resources.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Inadvertently exposing cloud resources (e.g., storage buckets, virtual machines, databases, load balancers) to the public internet creates easily exploitable attack vectors.
+**Mitigation Rule:** Prevent public access to all resources by default. Configure network security groups, bucket policies, and security group rules to explicitly deny public ingress unless a justified and limited exception is required and documented. Ensure storage buckets explicitly block public access.
+
+### Risk: Network Exposure
+**Summary:** Overly permissive network security group rules, firewalls, or routing configurations can expose internal systems and services to unauthorized access.
+**Mitigation Rule:** Define network security rules (e.g., AWS Security Groups, Azure Network Security Groups, GCP Firewall Rules) with the strictest possible ingress and egress rules, limiting traffic to only required ports and trusted IP ranges or security groups/service endpoints. Avoid `0.0.0.0/0` for ingress unless for public-facing services with WAF/CDN in front.
+
+### Risk: Data in Transit Unencrypted
+**Summary:** Transmitting sensitive data over unencrypted channels (e.g., HTTP instead of HTTPS) makes it vulnerable to eavesdropping and man-in-the-middle attacks.
+**Mitigation Rule:** Enforce encryption for all data in transit. Configure load balancers, API gateways, and internal communication paths to use TLS/SSL (HTTPS) by default. Redirect HTTP to HTTPS. For inter-service communication, leverage private endpoints or service mesh with encryption.
+
+### Risk: Insufficient Logging and Monitoring
+**Summary:** Lack of comprehensive audit logging and security event monitoring hinders incident detection, investigation, and forensic analysis across cloud environments.
+**Mitigation Rule:** Enable extensive logging for all critical services and resources (e.g., API calls, network flow logs, database access, object access) and ensure logs are centrally collected, securely stored, and retained according to compliance requirements. Integrate logs with security information and event management (SIEM) solutions.
+
+### Risk: Hardcoded Secrets
+**Summary:** Embedding sensitive credentials, API keys, or private keys directly within HCL code creates a severe security vulnerability, enabling unauthorized access if the code is compromised.
+**Mitigation Rule:** Never hardcode any sensitive values. Utilize cloud-native secret management services (e.g., AWS Secrets Manager, Azure Key Vault, GCP Secret Manager) and retrieve secrets at runtime via secure mechanisms (e.g., IAM roles, managed identities).
+
+### Risk: Vulnerable Default Configurations
+**Summary:** Deploying resources with default, unhardened configurations or outdated software versions can introduce known vulnerabilities and expose systems to attack.
+**Mitigation Rule:** Override insecure default configurations. Always specify secure settings for resources like database versions, operating system images, and security features. Ensure all deployed resources are based on hardened images/AMIs and kept updated.
+
+### Risk: Missing Security Headers / WAF Protection
+**Summary:** Web applications lacking essential security headers or fronted by a Web Application Firewall (WAF) are susceptible to common web exploits like XSS, SQL injection, and DDoS attacks.
+**Mitigation Rule:** Configure web-facing resources with appropriate security headers (e.g., Strict-Transport-Security, X-Content-Type-Options, Content-Security-Policy). Deploy and configure cloud-native Web Application Firewalls (e.g., AWS WAF, Azure WAF, GCP Cloud Armor) for all public-facing web applications and APIs.

--- a/hcl/terraform/CLAUDE.md
+++ b/hcl/terraform/CLAUDE.md
@@ -1,0 +1,33 @@
+As a security-aware infrastructure engineer, generate secure HCL configurations using Terraform that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others). Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform. Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code. Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards. **Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+### Risk: Excessive Permissions / Least Privilege Violation
+**Summary:** Granting overly broad permissions to identities or resources, leading to potential privilege escalation or unauthorized access across cloud platforms.
+**Mitigation Rule:** Design all Identity and Access Management (IAM) policies (for roles, users, groups, and service accounts) using the principle of least privilege, granting only the minimum necessary actions on the required resources. Avoid wildcard permissions (`*`) for actions or resources unless strictly unavoidable and tightly constrained by conditions. Ensure explicit resource ARNs/IDs are used where possible.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption, making it vulnerable to unauthorized access if storage is compromised across cloud environments.
+**Mitigation Rule:** Mandate encryption at rest for all storage services, including object storage (e.g., S3, Azure Blob, GCP Cloud Storage), databases, message queues, and block storage volumes. Prioritize customer-managed keys (CMK) over cloud-managed keys, and ensure all relevant Terraform resources explicitly enable and configure encryption.
+
+### Risk: Unencrypted Data in Transit
+**Summary:** Transmitting sensitive data over unencrypted channels, exposing it to interception during network communication between services or clients.
+**Mitigation Rule:** Ensure all network communications, including client-to-service, inter-service, and cross-VPC/VNet traffic, utilize encryption in transit. Configure load balancers for HTTPS/TLS, enforce secure database connections, and use VPNs or private links for secure cross-network communication.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Exposing infrastructure components such as databases, storage buckets, or compute instances directly to the public internet, creating easily discoverable attack vectors.
+**Mitigation Rule:** Prevent public access to sensitive resources by default. Configure network security groups, network access control lists, and firewall rules to restrict inbound traffic to only necessary ports from specific, trusted IP ranges or internal networks. For object storage, ensure public access is explicitly blocked.
+
+### Risk: Insecure Network Configuration
+**Summary:** Configuring overly permissive network security group or firewall rules that allow unrestricted inbound/outbound traffic (e.g., `0.0.0.0/0` on sensitive ports).
+**Mitigation Rule:** Configure network access controls (e.g., AWS Security Groups, Azure Network Security Groups, GCP Firewall Rules) with the principle of least privilege. Allow only essential ports and protocols from specific, trusted IP ranges or internal security groups/subnets. Strictly avoid `0.0.0.0/0` inbound access on administrative ports (e.g., SSH, RDP) or sensitive application ports.
+
+### Risk: Lack of Secret Management Integration
+**Summary:** Hardcoding sensitive values like credentials, API keys, or database passwords directly into configuration files or Terraform state, leading to critical exposure.
+**Mitigation Rule:** Never hardcode sensitive information within HCL configurations. Always integrate with cloud-native secret management services (e.g., AWS Secrets Manager, Azure Key Vault, Google Secret Manager) for storing and retrieving secrets securely at runtime, referencing them dynamically within Terraform configurations.
+
+### Risk: Insufficient Logging and Monitoring
+**Summary:** Absence of comprehensive logging, auditing, and monitoring capabilities hinders the timely detection and response to security incidents across the cloud environment.
+**Mitigation Rule:** Enable and configure comprehensive logging (e.g., CloudTrail, Azure Activity Logs, GCP Cloud Audit Logs, VPC Flow Logs, application logs) for all deployed resources. Centralize logs for security analysis and auditing, and integrate with cloud-native monitoring and alerting services to detect anomalies and security events effectively.
+
+### Risk: Unrestricted Cross-Account/Service Access
+**Summary:** Configuring trust relationships or service roles that grant overly broad access to other accounts, cloud services, or external identities, potentially leading to unauthorized data exfiltration or resource manipulation.
+**Mitigation Rule:** Define explicit and granular trust policies for cross-account roles, service-linked roles, and service accounts. Restrict the principals who can assume roles and the actions they can perform. Do not use `*` for principal or `Action` in trust policies unless strictly necessary and with strong conditions that limit scope.

--- a/hcl/terraform/CONVENTIONS.md
+++ b/hcl/terraform/CONVENTIONS.md
@@ -1,0 +1,37 @@
+As a security-aware infrastructure engineer, generate secure HCL configurations using Terraform that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+**Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+### Risk: Excessive Permissions
+**Summary:** Granting overly broad or unnecessary permissions to identities or services can lead to privilege escalation or unauthorized access if compromised.
+**Mitigation Rule:** Apply the principle of least privilege. Explicitly define only the minimum necessary actions and resources for each IAM role, service principal, or identity. Avoid wildcard permissions (`*`) for actions or resources. Use condition keys to further restrict access based on context.
+
+### Risk: Unencrypted Storage (Data at Rest)
+**Summary:** Storing sensitive data unencrypted in cloud storage services, databases, or backups exposes information to unauthorized disclosure upon compromise.
+**Mitigation Rule:** Enforce encryption for all data at rest for all storage services, including object storage (e.g., S3 buckets, Azure Blob containers, GCS buckets), databases (e.g., RDS, Azure SQL, Cloud SQL, DynamoDB, CosmosDB), and block storage (e.g., EBS volumes, Azure Managed Disks). Prioritize customer-managed keys (CMK) when available and appropriate.
+
+### Risk: Public Network Exposure
+**Summary:** Resources directly exposed to the public internet without proper access controls create a vast attack surface and invite unauthorized access.
+**Mitigation Rule:** Default all resources to private network access. Prohibit public IP assignments for compute instances, databases, and internal services unless strictly required and justified. Configure network access controls (e.g., AWS Security Groups, Azure Network Security Groups, GCP Firewall Rules) to explicitly deny all inbound traffic by default, allowing only necessary, tightly scoped access from known sources.
+
+### Risk: Insecure Data in Transit
+**Summary:** Unencrypted data transfer between services or over public networks can lead to interception and disclosure of sensitive information.
+**Mitigation Rule:** Enforce TLS/SSL for all inter-service communication and external connections. Mandate HTTPS for web services, secure protocols for database connections, and secure tunneling (e.g., VPN, Direct Connect, ExpressRoute, Cloud Interconnect) for cross-network communication. Disable insecure protocols.
+
+### Risk: Insufficient Logging and Monitoring
+**Summary:** Lack of comprehensive activity logging and real-time monitoring hinders incident detection, forensic analysis, and compliance auditing.
+**Mitigation Rule:** Enable central logging for all critical cloud resources and services (e.g., AWS CloudTrail, Azure Activity Logs and Diagnostic Settings, GCP Cloud Audit Logs, VPC Flow Logs). Configure appropriate log retention policies for compliance and operational needs. Forward logs to a centralized, secured log management system for analysis and alerting.
+
+### Risk: Hardcoded Sensitive Information
+**Summary:** Embedding secrets like API keys, database credentials, or private keys directly within HCL configuration files or code creates severe security vulnerabilities.
+**Mitigation Rule:** Never hardcode sensitive values directly in Terraform configurations. Always integrate with cloud-native secret management services (e.g., AWS Secrets Manager, Azure Key Vault, Google Secret Manager) or enterprise-grade secret stores. Reference secrets dynamically at runtime from these secure vaults.
+
+### Risk: Insecure Default Configurations
+**Summary:** Relying on cloud provider default settings, which often prioritize ease of use over security, can inadvertently expose resources or grant excessive privileges.
+**Mitigation Rule:** Explicitly override all insecure default settings for every resource. Configure all resources to be secure-by-default (e.g., private S3 buckets, disabled public access, restricted security group rules, disabled public endpoints for databases, secure compute instance images). Always specify security settings rather than relying on implicit defaults.
+
+### Risk: Lack of Network Segmentation
+**Summary:** Flat networks without proper segmentation allow attackers to move laterally across compromised resources, increasing the blast radius of a breach.
+**Mitigation Rule:** Implement logical network segmentation within the cloud environment using subnets, virtual private clouds/networks, and security groups/network security groups to isolate different application tiers, environments (dev, staging, prod), and critical workloads. Enforce strict firewall rules between segments to control traffic flow and limit lateral movement.

--- a/hcl/terraform/HCL_Terraform_rules.mdc
+++ b/hcl/terraform/HCL_Terraform_rules.mdc
@@ -1,0 +1,51 @@
+---
+description: Enforce secure infrastructure-as-code best practices for HCL/Terraform configurations to prevent common cloud security misconfigurations.
+globs: **/*.hcl, **/*.tf, **/*.tfvars
+alwaysApply: false
+---
+
+As a security-aware infrastructure engineer, generate secure HCL configurations using Terraform that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+**Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform such as AWS Secrets Manager, Azure Key Vault, or Google Secret Manager.
+
+### Risk: Excessive Permissions
+**Summary:** Granting overly broad permissions can lead to unauthorized access and privilege escalation across all cloud environments.
+**Mitigation Rule:** Implement the principle of least privilege for all IAM roles, users, and service accounts. Restrict permissions to the minimum necessary actions and resources required for a function. Explicitly deny dangerous actions where possible. For AWS, use fine-grained IAM policies. For Azure, use custom roles or built-in roles with careful assignment. For GCP, leverage custom roles and service account permissions.
+
+### Risk: Unencrypted Data at Rest/In Transit
+**Summary:** Storing or transmitting unencrypted sensitive data can result in data breaches and non-compliance across cloud platforms.
+**Mitigation Rule:** Ensure all data at rest in storage services (e.g., S3 buckets, Azure Storage accounts, GCP Cloud Storage) is encrypted using server-side encryption with customer-managed keys (CMKs) where possible, or platform-managed keys by default. Enforce encryption in transit for all network communication, using TLS 1.2+ for load balancers, APIs, and inter-service communication.
+
+### Risk: Publicly Exposed Resources
+**Summary:** Inadvertently exposing cloud resources (storage, databases, virtual machines) to the public internet creates significant attack vectors and data leakage risks.
+**Mitigation Rule:** Prevent public access to storage buckets, databases, compute instances, and other critical infrastructure unless explicitly required and secured. Configure network access controls (security groups, network security groups, firewall rules) to block inbound traffic from the internet by default. Ensure public IPs are not assigned to sensitive resources.
+
+### Risk: Network Exposure & Ingress/Egress Control
+**Summary:** Misconfigured network access controls can allow unauthorized inbound or outbound connections, leading to data exfiltration or unauthorized access.
+**Mitigation Rule:** Restrict network ingress to only necessary ports and trusted IP ranges. Limit egress to only required external services. Use network segmentation (VPCs, VNets, shared VPCs) and enforce strict network security group/firewall rules. Avoid "0.0.0.0/0" rules for inbound access on production resources.
+
+### Risk: Logging and Monitoring Gaps
+**Summary:** Inadequate logging and monitoring can prevent timely detection of security incidents, hindering incident response and forensic analysis.
+**Mitigation Rule:** Enable comprehensive logging for all critical cloud services (e.g., CloudTrail, Azure Activity Logs, GCP Cloud Audit Logs, VPC Flow Logs). Centralize logs in a secure, immutable storage location. Ensure audit trails are configured to capture all API calls, access attempts, and configuration changes for security monitoring and compliance.
+
+### Risk: Weak Secrets Management
+**Summary:** Storing secrets insecurely or hardcoding them in infrastructure code exposes sensitive credentials to compromise.
+**Mitigation Rule:** Do not hardcode any sensitive values (API keys, database credentials, encryption keys, tokens) directly in Terraform configurations or variable files. Instead, integrate with cloud-native secret management services like AWS Secrets Manager, Azure Key Vault, or Google Secret Manager to retrieve secrets at runtime. Encrypt secrets even when stored in environment variables.
+
+### Risk: Unpatched/Outdated Components
+**Summary:** Using outdated operating systems, container images, or application runtimes with known vulnerabilities can expose resources to exploitation.
+**Mitigation Rule:** Provision infrastructure with the latest stable and securely configured operating system images, container images, and runtime versions. Implement automated patching or update mechanisms for compute instances and managed services where applicable. Ensure Terraform modules specify minimum acceptable versions for providers and modules.
+
+### Risk: Insecure Default Configurations
+**Summary:** Cloud services often come with insecure default settings that, if not explicitly overridden, can lead to security vulnerabilities.
+**Mitigation Rule:** Always explicitly define secure configurations, even if they align with current defaults, to ensure future changes in defaults do not introduce vulnerabilities. Override all default settings that compromise security (e.g., public access, unencrypted storage, unrestricted network rules) with secure-by-default options.
+
+### Risk: Missing or Weak Multi-Factor Authentication (MFA)
+**Summary:** Lack of MFA for privileged access to cloud accounts increases the risk of credential compromise and unauthorized access.
+**Mitigation Rule:** Enforce Multi-Factor Authentication (MFA) for all root accounts and administrative users/roles across all cloud providers. Mandate MFA for all privileged access paths to cloud consoles and APIs, including programmatic access.
+
+### Risk: Inadequate Resource Tagging/Inventory
+**Summary:** Poor resource tagging can lead to orphaned resources, misconfigurations, and hinder security auditing and cost management.
+**Mitigation Rule:** Implement mandatory and consistent tagging for all provisioned cloud resources. Tags should include information critical for security, such as environment (prod/dev), owner, application, and compliance requirements, to facilitate inventory, policy enforcement, and security assessments.

--- a/hcl/terraform/copilot-instructions.md
+++ b/hcl/terraform/copilot-instructions.md
@@ -1,0 +1,39 @@
+- As a security-aware infrastructure engineer, generate secure HCL configurations using Terraform that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+- Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+- Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+- Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+- **Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+## Infrastructure Security Best Practices for HCL + Terraform
+
+### Risk: Excessive Permissions / Least Privilege Violation
+**Summary:** Granting more permissions than necessary to identities (users, roles, service principals) or resources significantly increases the blast radius of a compromise across all cloud platforms.
+**Mitigation Rule:** Configure all IAM policies, roles, and service accounts with the absolute minimum permissions required for their intended function, strictly adhering to the principle of least privilege. Explicitly deny unnecessary actions by default, and avoid wildcard permissions (`*`) unless absolutely unavoidable and justified by inline comments.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption in storage services, databases, or disk volumes exposes it to unauthorized access if the underlying infrastructure is compromised, common across all cloud environments.
+**Mitigation Rule:** Ensure all data at rest is encrypted by default using server-side encryption with platform-managed keys or customer-managed keys (CMK) for higher control. For storage buckets, databases, and disk volumes, explicitly enable encryption, preferably with CMKs, and enforce it with appropriate bucket policies or database configurations.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Exposing sensitive resources like storage buckets, databases, or virtual machines directly to the public internet without proper justification or access controls creates critical attack vectors.
+**Mitigation Rule:** Configure all resources to be private by default. For storage services, explicitly block public access settings. For compute instances and databases, deploy them in private subnets and restrict inbound access to specific, necessary IP ranges or other private resources using security groups or network ACLs.
+
+### Risk: Insecure Network Segmentation / Overly Permissive Firewall Rules
+**Summary:** Lack of proper network segmentation and overly broad inbound/outbound firewall rules (security groups, network security groups, firewall rules) enable unauthorized lateral movement and expose resources to unnecessary network traffic.
+**Mitigation Rule:** Implement robust network segmentation using private subnets, VPCs, or VNets. Restrict inbound and outbound network access using the most granular firewall rules possible, allowing only explicitly required ports and protocols from known, trusted sources. Avoid `0.0.0.0/0` (any) in inbound rules unless for services designed to be publicly accessible, and even then, limit to necessary ports.
+
+### Risk: Lack of Encryption in Transit
+**Summary:** Transmitting data between services or to end-users without encryption (e.g., unencrypted HTTP) exposes it to eavesdropping and tampering during transit across various network paths.
+**Mitigation Rule:** Enforce encryption in transit for all network communication by utilizing HTTPS/TLS for load balancers, API gateways, and inter-service communication. Configure load balancers to redirect HTTP traffic to HTTPS, and ensure databases and message queues enforce SSL/TLS connections.
+
+### Risk: Insufficient Logging and Monitoring
+**Summary:** The absence of comprehensive logging, auditing, and real-time monitoring makes detecting, investigating, and responding to security incidents extremely difficult or impossible across cloud platforms.
+**Mitigation Rule:** Enable extensive logging for all cloud resources, including API activity (e.g., CloudTrail, Azure Activity Logs, Cloud Audit Logs), network flow logs (VPC Flow Logs, NSG Flow Logs, VPC Flow Logs), and resource-specific logs (e.g., S3 access logs, database query logs). Route these logs to a centralized logging solution and configure security alerts for anomalous activities.
+
+### Risk: Hardcoded Secrets / Insecure Credentials Management
+**Summary:** Embedding sensitive information like API keys, database credentials, or private keys directly within HCL code or configuration files leads to major security breaches if the code repository is compromised.
+**Mitigation Rule:** Never hardcode sensitive values directly in Terraform configurations. Utilize cloud-native secret management services (e.g., AWS Secrets Manager, Azure Key Vault, Google Secret Manager) to store and retrieve all sensitive credentials and API keys securely at runtime. Ensure proper IAM policies govern access to these secret stores.
+
+### Risk: Outdated / Unpatched Base Images
+**Summary:** Deploying instances or containers based on outdated or unpatched base images introduces known vulnerabilities into the infrastructure, creating exploitable weaknesses before runtime.
+**Mitigation Rule:** Always specify the latest secure and patched base images (e.g., AMIs, VM images, container images) provided by cloud providers or trusted sources. Integrate image scanning processes into CI/CD pipelines and reference image IDs or versions known to be secure and up-to-date in Terraform configurations where applicable.

--- a/technologies.json
+++ b/technologies.json
@@ -6,6 +6,8 @@
     ["JavaScript", "React"],
     ["JavaScript", "Node.js"],
     [".NET", "ASP.NET Core"],
-    ["C", "any"]
+    ["C", "any"],
+    ["HCL", "Terraform"],
+    ["YAML", "Cloudformation"]
   ]
 }

--- a/yaml/cloudformation/.clinerules
+++ b/yaml/cloudformation/.clinerules
@@ -1,0 +1,45 @@
+# Secure Infrastructure-as-Code Generation Rules for YAML Cloudformation
+
+As a security-aware infrastructure engineer, generate secure YAML configurations using Cloudformation that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+**Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+## Top Infrastructure Security Risks and Mitigation Rules
+
+### Risk: Excessive Permissions
+**Summary:** Granting overly broad or unnecessary permissions to identities and services significantly increases the blast radius of a breach across all cloud platforms.
+**Mitigation Rule:** Always apply the principle of least privilege, ensuring IAM roles, users, and service principals in Cloudformation templates grant only the absolute minimum required permissions for resources to function securely. Prioritize fine-grained permissions over wildcards, and explicitly deny actions where possible.
+
+### Risk: Publicly Accessible Storage
+**Summary:** Unrestricted public access to cloud storage buckets (e.g., S3, Azure Blob, GCP Cloud Storage) can lead to data breaches and unauthorized data exposure.
+**Mitigation Rule:** Configure all storage resources in Cloudformation to block public access by default, enforce bucket policies that restrict access to authenticated users or specific VPC endpoints, and never allow public read/write permissions unless explicitly justified and secured via other controls.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption at rest in databases, storage volumes, and other services leaves it vulnerable to unauthorized access if the underlying storage is compromised.
+**Mitigation Rule:** Mandate encryption at rest for all data storage, databases, and message queues provisioned via Cloudformation, utilizing service-managed encryption keys (SSE-S3, CMK, etc.) or customer-managed keys (KMS, Key Vault, Cloud KMS) where compliance requirements dictate.
+
+### Risk: Network Exposure
+**Summary:** Overly permissive security groups, network ACLs, and firewall rules can expose internal resources and services to the public internet or untrusted networks, creating attack vectors.
+**Mitigation Rule:** Design network security configurations in Cloudformation to enforce strict ingress and egress rules, limiting traffic to only necessary ports and trusted IP ranges or security groups, implementing network segmentation, and avoiding 0.0.0.0/0 ingress for non-public-facing services.
+
+### Risk: Missing Logging & Monitoring
+**Summary:** The absence of comprehensive logging and monitoring can prevent timely detection of security incidents, unauthorized activities, and compliance violations across cloud environments.
+**Mitigation Rule:** Ensure Cloudformation templates provision and configure essential logging and monitoring services (e.g., CloudTrail, CloudWatch Logs, Azure Monitor, GCP Cloud Logging) for all critical resources, enable flow logs for VPCs, and integrate with centralized security information and event management (SIEM) systems where applicable.
+
+### Risk: Insecure Data in Transit
+**Summary:** Transmitting sensitive data over unencrypted channels (e.g., HTTP instead of HTTPS) makes it vulnerable to eavesdropping and man-in-the-middle attacks.
+**Mitigation Rule:** Always enforce encryption in transit for all network communication, configuring Load Balancers, API Gateways, and other services in Cloudformation to require TLS/SSL version 1.2 or higher, using strong ciphers, and redirecting HTTP to HTTPS.
+
+### Risk: Hardcoded Secrets
+**Summary:** Embedding sensitive credentials like API keys, passwords, or database connection strings directly within infrastructure-as-code templates exposes them to version control systems and unauthorized access.
+**Mitigation Rule:** Never include any hardcoded secrets in Cloudformation templates. Instead, always integrate with cloud-native secret management services (e.g., AWS Secrets Manager, AWS Parameter Store, Azure Key Vault, GCP Secret Manager) to retrieve credentials securely at runtime.
+
+### Risk: Lack of Deletion Protection
+**Summary:** Accidental or malicious deletion of critical infrastructure components can lead to service outages and data loss.
+**Mitigation Rule:** For critical or stateful resources (e.g., databases, storage buckets, EC2 instances with persistent data), configure DeletionPolicy attributes in Cloudformation to `Retain` or `Snapshot` to prevent unintended data loss or service disruption upon stack deletion.
+
+### Risk: Outdated Compute Images
+**Summary:** Deploying compute instances (VMs, containers) based on outdated or unhardened operating system images introduces known vulnerabilities that can be exploited.
+**Mitigation Rule:** Always specify the latest secure and patched machine images (e.g., AMIs, VM images, container images) in Cloudformation templates. Prefer using hardened images provided by cloud providers or reputable vendors, and integrate with image scanning and patching pipelines.

--- a/yaml/cloudformation/.windsurfrules
+++ b/yaml/cloudformation/.windsurfrules
@@ -1,0 +1,43 @@
+---
+trigger: glob
+description: Enforces secure configurations for YAML CloudFormation infrastructure, preventing common cloud security misconfigurations.
+globs: **/*.yaml, **/*.yml
+---
+```
+As a security-aware infrastructure engineer, generate secure YAML configurations using Cloudformation that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others). Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform. Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code. Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards. **Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+### Risk: Excessive Permissions
+**Summary:** Granting overly broad permissions can lead to privilege escalation and unauthorized access to resources across cloud environments.
+**Mitigation Rule:** Define IAM roles and policies with the absolute minimum necessary permissions (least privilege). Use specific resource ARNs, conditions, and action types. Avoid wildcard `*` permissions except for tightly controlled read-only access where appropriate. Ensure all policies are regularly reviewed and validated for necessity, regardless of cloud platform (e.g., AWS IAM, Azure RBAC, GCP IAM).
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption at rest exposes it to unauthorized access if storage components are compromised or misconfigured.
+**Mitigation Rule:** Enforce server-side encryption for all storage services (e.g., S3 buckets, EBS volumes, RDS databases, Azure Storage, GCP Storage Buckets, Cloud SQL, Persistent Disks) using customer-managed keys (CMK) from a Key Management Service (KMS) where possible, or provider-managed keys (PMK) as a minimum. Configure services to reject unencrypted uploads.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Exposing sensitive or critical infrastructure resources directly to the public internet can lead to data breaches, denial of service, and unauthorized command execution.
+**Mitigation Rule:** Configure storage buckets, databases, load balancers, and compute instances (e.g., EC2, Azure VMs, GCP Compute Engine instances) to be private by default. Implement appropriate network access controls (e.g., security groups, NACLs, private subnets, Private Link/Service Endpoints) to restrict inbound access to only necessary sources (internal networks, specific IPs) for any internet-facing services. Block public access at the account or bucket level where supported.
+
+### Risk: Insecure Network Ingress/Egress Rules
+**Summary:** Overly permissive network security group, firewall, or network ACL rules can allow unauthorized traffic into or out of a virtual network, leading to lateral movement or data exfiltration.
+**Mitigation Rule:** Define network security group, network ACL, and firewall rules with the principle of least privilege, allowing only essential ingress and egress traffic on required ports and from/to specific IP ranges or other security groups. Avoid 0.0.0.0/0 for inbound rules unless absolutely necessary for public-facing services, and strictly limit outbound traffic to only required destinations.
+
+### Risk: Hardcoded Secrets and Credentials
+**Summary:** Embedding sensitive credentials, API keys, or passwords directly in infrastructure code creates significant security vulnerabilities and makes rotation difficult.
+**Mitigation Rule:** Never hardcode sensitive values directly in YAML configurations. Utilize cloud-native secret management services (e.g., AWS Secrets Manager, Azure Key Vault, Google Secret Manager) to store and retrieve all secrets securely. Reference these services within CloudFormation templates instead of plain-text values.
+
+### Risk: Insufficient Logging and Monitoring
+**Summary:** Lack of comprehensive logging and monitoring hinders the detection of security incidents, unauthorized activities, and compliance violations across the cloud environment.
+**Mitigation Rule:** Enable detailed logging for all critical services (e.g., CloudTrail, VPC Flow Logs, S3 access logs, RDS logs, Azure Activity Logs, Azure Monitor, GCP Audit Logs, Cloud Logging). Configure logs to be encrypted, immutable, and delivered to centralized logging solutions for long-term retention and analysis. Enable monitoring and alerting for suspicious activities and configuration changes.
+
+### Risk: Misconfigured Compute Instance Defaults
+**Summary:** Deploying compute instances with insecure default settings (e.g., default admin passwords, open RDP/SSH ports, unhardened OS images) creates easy entry points for attackers.
+**Mitigation Rule:** Always specify the latest secure and hardened operating system images (e.g., CIS hardened AMIs/VM images). Configure compute instances with instance profiles/managed identities for permissions instead of access keys. Disable default administrative access (e.g., password-based SSH/RDP) and enforce key-pair or bastion host access. Remove unnecessary software and services.
+
+### Risk: Insecure Load Balancer/API Gateway Configuration
+**Summary:** Misconfigured load balancers or API gateways can expose backend services, allow unencrypted traffic, or provide inadequate protection against common web attacks.
+**Mitigation Rule:** Enforce HTTPS/SSL/TLS for all external-facing load balancers and API gateways. Utilize the latest secure TLS versions and strong cipher suites. Integrate with Web Application Firewalls (WAF) to protect against common web exploits. Configure proper health checks and timeout settings to ensure backend stability and availability.
+
+### Risk: Lack of Resource Deletion Protection
+**Summary:** Accidental or malicious deletion of critical infrastructure resources can lead to significant service disruption and data loss.
+**Mitigation Rule:** Enable deletion protection for critical resources that support it (e.g., CloudFormation stacks, S3 buckets, RDS instances, Azure Storage Accounts, GCP Cloud SQL instances). Implement CloudFormation Stack Policy to prevent unintended updates or deletions of critical resources or properties.

--- a/yaml/cloudformation/AGENTS.md
+++ b/yaml/cloudformation/AGENTS.md
@@ -1,0 +1,43 @@
+# Cloudformation Security Codex Rules for LLM-Driven Infrastructure Generation
+
+As a security-aware infrastructure engineer, generate secure YAML configurations using Cloudformation that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others). Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform. Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code. Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+
+**Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform (e.g., AWS Secrets Manager, Azure Key Vault, Google Secret Manager).
+
+---
+
+### Risk: Excessive Permissions
+**Summary:** Granting more permissions than necessary to resources or identities leads to broader attack surfaces and privilege escalation risks across cloud platforms.
+**Mitigation Rule:** Define IAM policies (AWS IAM, Azure RBAC roles, GCP IAM roles) with explicit `Allow` and `Deny` statements, strictly adhering to the principle of least privilege. Attach policies directly to specific resources or roles, avoiding wildcard permissions (`*`) unless absolutely necessary and justified with inline comments.
+
+### Risk: Unencrypted Data at Rest and In Transit
+**Summary:** Storing or transmitting sensitive data without encryption can lead to data breaches if compromised.
+**Mitigation Rule:** Enforce server-side encryption by default for all storage services (e.g., S3 Bucket Encryption, EBS Encryption, RDS Encryption, Azure Storage Encryption, GCP Storage Encryption) using managed encryption keys (KMS, Key Vault, Cloud KMS). Require all network traffic between services and to/from endpoints to use TLS 1.2+ for data in transit.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Exposing resources like storage buckets, databases, or compute instances to the public internet without justification creates significant attack vectors.
+**Mitigation Rule:** Configure all newly provisioned storage buckets, databases, and compute instances to be private by default. For storage services, enable Block Public Access settings (e.g., AWS S3 Block Public Access). Ensure no public IPs are assigned to database instances or critical application servers unless explicitly required and fronted by a Web Application Firewall (WAF).
+
+### Risk: Insecure Network Exposure
+**Summary:** Overly permissive network rules or publicly exposed management interfaces can allow unauthorized access to infrastructure.
+**Mitigation Rule:** Design networks using private subnets within VPCs/VNets. Implement granular security group (AWS), network security group (Azure), or firewall rules (GCP) to restrict inbound and outbound traffic to only essential ports and source/destination IP ranges. Never expose administrative ports (e.g., SSH 22, RDP 3389) directly to the internet; use bastion hosts, VPNs, or secure access methods.
+
+### Risk: Logging and Monitoring Deficiencies
+**Summary:** Lack of comprehensive logging and monitoring can delay detection of security incidents and impede forensic analysis.
+**Mitigation Rule:** Mandate the enabling of comprehensive audit logging for all critical CloudFormation-deployed resources (e.g., CloudTrail for AWS, Azure Activity Logs and Diagnostic Settings for Azure, Cloud Audit Logs for GCP). Configure log destinations to secure, centralized logging services, and establish monitoring and alerting for security-relevant events and misconfigurations.
+
+### Risk: Insecure API Gateway/Load Balancer Configuration
+**Summary:** Misconfigured API Gateways or Load Balancers can expose backend services, allow unauthenticated access, or fail to enforce proper security controls.
+**Mitigation Rule:** Configure all API Gateway endpoints and Load Balancers (ALB, NLB, Azure Application Gateway, GCP Load Balancer) to enforce HTTPS/TLS 1.2+ listener policies. Implement request throttling, integrate with Web Application Firewalls (WAFs) for OWASP Top 10 protection, and apply strong authentication/authorization mechanisms (e.g., IAM authorizers, JWT validation) for all endpoints.
+
+### Risk: Missing Resource Tagging for Governance/Security
+**Summary:** Absence of consistent tagging hinders resource identification, cost attribution, and security policy enforcement, leading to governance gaps.
+**Mitigation Rule:** Require a standardized set of tags for all deployable resources within CloudFormation templates, including `Environment`, `Application`, `Owner`, `CostCenter`, and `Confidentiality` (e.g., Public, Internal, Confidential). Use tags to facilitate automated policy enforcement, resource identification, and cost allocation.
+
+### Risk: Insecure Service Principals/Managed Identities
+**Summary:** Granting overly broad permissions to service accounts or managed identities (used by applications) can lead to horizontal privilege escalation within the cloud environment.
+**Mitigation Rule:** When defining service roles (AWS IAM Roles), managed identities (Azure), or service accounts (GCP), apply the principle of least privilege by granting only the minimum necessary permissions required for the application or service to function. Avoid broad permissions like `*` or `Admin` policies, and restrict access to specific resources where possible.
+
+### Risk: Vulnerable Compute Images/Runtimes
+**Summary:** Deploying instances or containers with unpatched software vulnerabilities can be exploited by attackers, leading to system compromise.
+**Mitigation Rule:** Specify the use of the latest stable and patched machine images (AMIs, Azure VM Images, GCP Compute Images) or container images from trusted, official sources. Avoid using outdated or custom images without a robust patch management process. Prioritize serverless or managed services to offload patching responsibilities where appropriate.

--- a/yaml/cloudformation/CLAUDE.md
+++ b/yaml/cloudformation/CLAUDE.md
@@ -1,0 +1,43 @@
+As a security-aware infrastructure engineer, generate secure YAML configurations using Cloudformation that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+**Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+---
+
+### Risk: Excessive Permissions
+**Summary:** Granting overly broad or unnecessary permissions to identities (users, roles, service accounts) or resources can lead to unauthorized access, privilege escalation, and data exfiltration across cloud platforms.
+**Mitigation Rule:** Configure all IAM roles, policies, and resource-based policies to follow the principle of least privilege, granting only the minimum necessary permissions required for specific functions and actions within CloudFormation templates. Ensure explicit deny statements where appropriate and leverage AWS IAM Condition keys, Azure ABAC, or GCP IAM Conditions for fine-grained control.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption at rest exposes it to unauthorized access if the underlying storage infrastructure is compromised.
+**Mitigation Rule:** Enable default encryption at rest for all storage services (e.g., S3 buckets, EBS volumes, RDS instances, Azure Storage Accounts, GCP Cloud Storage buckets, database instances) by explicitly setting encryption properties in CloudFormation, ideally utilizing customer-managed keys (CMK) or provider-managed keys (PMK) where applicable, to ensure data protection.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Inadvertently exposing resources like storage buckets, databases, virtual machines, or APIs to the public internet creates severe attack vectors and facilitates data breaches or unauthorized operations.
+**Mitigation Rule:** Configure all resources to be private by default. For CloudFormation, explicitly set block public access properties for S3 buckets, disable public IPs for EC2 instances/VMs, configure private endpoints for databases, and ensure API Gateways or load balancers do not expose sensitive backend services without strict authorization and network controls.
+
+### Risk: Insecure Network Configuration
+**Summary:** Overly permissive network ingress or egress rules (e.g., security groups, NACLs, firewall rules) can expose internal systems to external threats or facilitate data exfiltration.
+**Mitigation Rule:** Restrict network access to the absolute minimum necessary ports and IP ranges. Define explicit ingress and egress rules in CloudFormation for security groups, network ACLs, and firewall rules that only allow required traffic, prioritizing private network communication and utilizing service endpoints or private links where available.
+
+### Risk: Insufficient Logging and Monitoring
+**Summary:** Lack of comprehensive logging, auditing, and real-time monitoring hinders incident detection, forensic analysis, compliance adherence, and timely response to security events.
+**Mitigation Rule:** Enable centralized logging and auditing for all critical services and API calls (e.g., AWS CloudTrail, CloudWatch Logs; Azure Monitor, Activity Logs; GCP Cloud Logging, Audit Logs). Configure retention policies and integrate with security information and event management (SIEM) solutions or relevant cloud security services within CloudFormation.
+
+### Risk: Insecure In-Transit Encryption
+**Summary:** Transmitting sensitive data over unencrypted channels (HTTP instead of HTTPS, unencrypted database connections) can lead to eavesdropping and man-in-the-middle attacks.
+**Mitigation Rule:** Enforce encryption in transit for all data communication. Configure Load Balancers, API Gateways, and web servers to only accept HTTPS/TLS connections, utilize appropriate SSL certificates, and ensure database connections enforce SSL/TLS, explicitly disabling unencrypted protocols in CloudFormation resource definitions.
+
+### Risk: Outdated/Vulnerable Compute Images
+**Summary:** Deploying compute instances (VMs, containers) from outdated, unpatched, or insecure base images introduces known vulnerabilities, increasing the risk of compromise.
+**Mitigation Rule: Always specify the latest secure and patched machine images (AMIs for AWS, VM Images for Azure/GCP) in CloudFormation templates. Integrate image scanning processes and ensure that base images are regularly updated to mitigate known vulnerabilities. Avoid using custom or community images without thorough security vetting.
+
+### Risk: Inadequate Secret Management
+**Summary:** Hardcoding sensitive values or storing them insecurely (e.g., in plaintext in source code, configuration files, or public repositories) leads to credential compromise and unauthorized access.
+**Mitigation Rule:** Never hardcode any secrets, credentials, API keys, or database passwords directly into CloudFormation templates or associated configurations. Utilize dedicated cloud-native secret management services (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager) for storing and retrieving sensitive information securely at runtime.
+
+### Risk: Unsecured Database Configurations
+**Summary:** Default or lax database configurations, such as weak authentication, public accessibility, or missing encryption, create critical vulnerabilities that can lead to data breaches or service disruption.
+**Mitigation Rule:** Enforce secure configurations for all database instances in CloudFormation. This includes strong, randomized administrator passwords, disabling public accessibility, enabling encryption at rest and in transit, configuring network isolation (e.g., private subnets), and disabling unnecessary default ports or features.

--- a/yaml/cloudformation/CONVENTIONS.md
+++ b/yaml/cloudformation/CONVENTIONS.md
@@ -1,0 +1,43 @@
+- As a security-aware infrastructure engineer, generate secure YAML configurations using Cloudformation that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+- Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+- Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+- Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+- **Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform (e.g., AWS Secrets Manager, AWS SSM Parameter Store SecureString, Azure Key Vault, Google Cloud Secret Manager).
+
+## Top Infrastructure Security Risks for YAML + Cloudformation
+
+### Risk: Excessive Permissions (IAM)
+**Summary:** Over-privileged roles, users, or resource policies grant more access than necessary, leading to potential unauthorized actions and data exposure across all cloud platforms.
+**Mitigation Rule:** Enforce the principle of least privilege. Define IAM policies (AWS::IAM::Policy, AWS::IAM::Role) with the most restrictive permissions required for the resource or service's function. Avoid wildcard `*` actions and resources unless absolutely necessary and justified. Utilize condition keys to further scope permissions based on context (e.g., IP address, time of day, source VPC). Prefer attribute-based access control (ABAC) where applicable.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing data without encryption in services like object storage, databases, or block storage volumes exposes sensitive information if data stores are compromised.
+**Mitigation Rule:** Mandate encryption at rest for all data storage resources (e.g., AWS::S3::Bucket, AWS::RDS::DBInstance, AWS::EC2::Volume, Azure Storage Accounts, GCP Storage Buckets). Configure server-side encryption with cloud-provider managed keys (KMS, Azure Key Vault, GCP KMS) or customer-managed keys (CMK) by default. Ensure CloudFormation templates explicitly specify encryption properties and key IDs where applicable.
+
+### Risk: Publicly Accessible Resources
+**Summary:** Unintentionally exposing storage buckets, databases, or network endpoints to the public internet creates a direct attack vector for data breaches and unauthorized access.
+**Mitigation Rule:** Configure all resources to be private by default. For storage, enable public access blocking (e.g., AWS::S3::Bucket PublicAccessBlockConfiguration). For databases, set `PubliclyAccessible: false`. For network resources, restrict ingress rules (e.g., AWS::EC2::SecurityGroup, Azure Network Security Group, GCP Firewall Rule) to only required source IPs or private networks, avoiding `0.0.0.0/0` for administrative or sensitive ports.
+
+### Risk: Insecure Network Configuration
+**Summary:** Overly permissive network ingress/egress rules or lack of network segmentation can facilitate unauthorized access, lateral movement, and data exfiltration within and outside the cloud environment.
+**Mitigation Rule:** Implement strict network segmentation using VPCs/VNets/VPC Networks and private subnets. Define network security rules (Security Groups, NSGs, Firewall Rules) with the principle of least privilege, allowing only essential communication between layers and services. Favor private endpoints (AWS PrivateLink, Azure Private Link, GCP Private Service Connect) for inter-service communication over public routes.
+
+### Risk: Improper Secret Referencing
+**Summary:** Storing or referencing sensitive values like API keys, database credentials, or private keys directly in CloudFormation templates, source code, or unencrypted parameters leads to critical security vulnerabilities.
+**Mitigation Rule:** Never hardcode or embed sensitive secrets directly in CloudFormation YAML templates or in plaintext parameters. Always use cloud-native secret management services (e.g., AWS Secrets Manager, AWS SSM Parameter Store SecureString, Azure Key Vault, Google Cloud Secret Manager) and reference these values securely using dynamic references, `Fn::ImportValue`, or other secure mechanisms supported by CloudFormation.
+
+### Risk: Missing or Inadequate Logging and Monitoring
+**Summary:** Lack of comprehensive logging, auditing, and monitoring for cloud resource activities hinders the detection of security incidents, unauthorized access attempts, and compliance violations.
+**Mitigation Rule:** Enable and configure robust logging for all services and resources (e.g., AWS CloudTrail, AWS CloudWatch Logs, Azure Monitor Activity Log, GCP Cloud Audit Logs, Cloud Logging). Ensure logs are centrally stored, encrypted, and have sufficient retention policies. Integrate logging with security information and event management (SIEM) systems for real-time threat detection and alerting.
+
+### Risk: Lack of Resource Deletion Protection
+**Summary:** Accidental or malicious deletion of critical infrastructure components or data stores can lead to significant downtime, data loss, or service disruption.
+**Mitigation Rule:** Enable deletion protection for critical resources (e.g., AWS::RDS::DBInstance `DeletionProtection`, AWS::S3::Bucket `PublicAccessBlockConfiguration` with `BlockPublicDeletes`, AWS::EC2::Instance `DisableApiTermination`, Azure SQL Database `AllowDataDelete` or soft delete options, GCP Cloud SQL `databaseFlags` for deletion protection) where supported, to prevent unintended removal.
+
+### Risk: Misconfigured Web Application Firewalls (WAF)
+**Summary:** Failing to deploy or properly configure WAFs for public-facing web applications leaves them vulnerable to common web exploits like SQL injection, cross-site scripting (XSS), and DDoS attacks.
+**Mitigation Rule:** Deploy and configure web application firewalls (e.g., AWS::WAFv2::WebACL, Azure WAF, Google Cloud Armor) in front of all internet-facing web applications. Implement rules to mitigate OWASP Top 10 risks, rate-based rules for DDoS protection, and IP reputation lists. Ensure WAF logs are enabled and integrated with monitoring solutions.
+
+### Risk: Insufficient Data Backup and Disaster Recovery
+**Summary:** Absence of automated backup strategies and a tested disaster recovery plan for critical data and applications can result in unrecoverable data loss and prolonged outages during incidents.
+**Mitigation Rule:** Implement automated and regular backup strategies for all critical data stores (e.g., AWS::RDS::DBInstance `BackupRetentionPeriod`, AWS::EBS::Snapshot schedules, Azure Backup, GCP Cloud SQL backups). Configure cross-region/cross-zone replication where appropriate for disaster recovery. Define and test recovery procedures for all critical applications.

--- a/yaml/cloudformation/YAML_Cloudformation_rules.mdc
+++ b/yaml/cloudformation/YAML_Cloudformation_rules.mdc
@@ -1,0 +1,50 @@
+---
+description: Enforces security best practices for YAML infrastructure configurations using Cloudformation.
+globs: "**/*.yaml, **/*.yml"
+alwaysApply: false
+---
+- As a security-aware infrastructure engineer, generate secure YAML configurations using Cloudformation that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+- Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+- Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+- Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+- **Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+### Risk: Excessive Permissions
+**Summary:** Overly broad permissions assigned to identities (roles, users, service accounts) lead to privilege escalation and unauthorized access across all cloud platforms.
+**Mitigation Rule:** When defining IAM roles, policies, and service accounts in CloudFormation, apply the principle of least privilege by specifying only the exact actions and resources required. Avoid using `*` for actions or resources unless absolutely necessary and documented. For AWS, use specific ARNs; for Azure, define custom roles with granular permissions; for GCP, use custom roles or predefined roles with explicit member bindings.
+
+### Risk: Public Access to Storage
+**Summary:** Unrestricted public access to data storage services can lead to data breaches and unauthorized data exfiltration across cloud providers.
+**Mitigation Rule:** Configure all CloudFormation storage resources (e.g., `AWS::S3::Bucket`, `Azure::Storage::StorageAccount`, `Google::Storage::Bucket`) to block public access by default. Ensure S3 bucket policies explicitly deny public reads/writes, Azure storage accounts disable public blob access, and GCP buckets enforce uniform bucket-level access and deny public read/write.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption at rest exposes it to unauthorized disclosure if the underlying storage is compromised.
+**Mitigation Rule:** Ensure all CloudFormation-defined data storage services (databases, object storage, block storage) are configured with encryption at rest enabled. Prioritize using Customer Managed Keys (CMK) via KMS (AWS), Azure Key Vault (Azure), or Cloud Key Management Service (GCP) over cloud-managed keys for sensitive data.
+
+### Risk: Network Exposure
+**Summary:** Overly permissive network security group (firewall) rules allow unauthorized access to services and instances from the internet or internal networks.
+**Mitigation Rule:** Define CloudFormation network security group rules (e.g., `AWS::EC2::SecurityGroup`, `Azure::Network::NetworkSecurityGroup`, `Google::Compute::Firewall`) with the most restrictive ingress and egress rules. Specify minimal required ports, protocols, and CIDR ranges, strictly avoiding `0.0.0.0/0` unless for well-justified and secured public endpoints.
+
+### Risk: Missing Logging and Monitoring
+**Summary:** Lack of comprehensive logging and monitoring hinders detection of security incidents, unauthorized activities, and compliance auditing across cloud environments.
+**Mitigation Rule:** Enable and configure comprehensive logging through CloudFormation for all critical resources, including API activity logs (e.g., AWS CloudTrail, Azure Activity Log, GCP Cloud Audit Logs), network flow logs (e.g., VPC Flow Logs, NSG Flow Logs), and resource-specific logs. Ensure logs are delivered to centralized, immutable storage and integrated with monitoring services.
+
+### Risk: Hardcoded Credentials/Weak Secrets
+**Summary:** Relying on default credentials, weak passwords, or unrotated access keys significantly increases the risk of unauthorized access.
+**Mitigation Rule:** Never hardcode sensitive values (passphrases, API keys, database credentials) directly within CloudFormation templates. Instead, use secure, cloud-native secret management services (e.g., AWS Secrets Manager, Azure Key Vault, Google Secret Manager) to retrieve secrets at runtime, or use CloudFormation parameters for non-sensitive, configuration-level values.
+
+### Risk: Insecure Data Transmission
+**Summary:** Transmitting sensitive data over unencrypted channels exposes it to eavesdropping and tampering.
+**Mitigation Rule:** Enforce encryption in transit for all communications defined within CloudFormation, including load balancers, API gateways, and database connections. Mandate the use of HTTPS/TLS 1.2+ for all public-facing and internal endpoints where sensitive data is exchanged.
+
+### Risk: Lack of Deletion Protection
+**Summary:** Accidental or malicious deletion of critical infrastructure resources can lead to service outages and data loss.
+**Mitigation Rule:** For critical CloudFormation resources that hold state or are difficult to recreate (e.g., databases, S3 buckets, EC2 instances), enable deletion protection or termination protection properties where available. For AWS S3 buckets, set `DeletionPolicy: Retain` or `Snapshot` and enable `BlockPublicAccess`.
+
+### Risk: Unpatched/Vulnerable Compute Environments
+**Summary:** Deploying applications on outdated or unpatched operating systems and runtime environments introduces known vulnerabilities.
+**Mitigation Rule:** When deploying compute resources (e.g., `AWS::EC2::Instance`, `Azure::Compute::VirtualMachine`, `Google::Compute::Instance`) via CloudFormation, specify the latest available secure and patched base images (AMIs, VM Images). Prioritize using managed services (e.g., AWS Fargate, Azure Container Instances, Google Cloud Run) where the cloud provider manages the underlying OS patching.
+
+### Risk: Unsecured Public Endpoints
+**Summary:** Public-facing endpoints without proper authentication, authorization, or rate limiting can be vulnerable to abuse, DDoS attacks, or unauthorized data access.
+**Mitigation Rule:** Configure public-facing endpoints (e.g., API Gateways, Load Balancers) in CloudFormation to enforce strict authentication, authorization, and ideally, rate limiting. Utilize Web Application Firewalls (WAFs) for DDoS protection and common web exploits, and ensure TLS certificates are properly managed and renewed.

--- a/yaml/cloudformation/copilot-instructions.md
+++ b/yaml/cloudformation/copilot-instructions.md
@@ -1,0 +1,43 @@
+As a security-aware infrastructure engineer, generate secure YAML configurations using Cloudformation that inherently prevent common cloud security misconfigurations across all major cloud providers (AWS, Azure, GCP, and others).
+Focus on implementing defense-in-depth principles, least privilege access, and secure-by-default configurations regardless of the target cloud platform.
+Use inline comments to clearly highlight critical security controls, compliance requirements, and any security assumptions made in the infrastructure code.
+Adhere strictly to cloud security best practices from frameworks like CIS Benchmarks, cloud provider security frameworks (AWS Well-Architected, Azure Security Benchmark, Google Cloud Security Command Center), and industry compliance standards.
+**Avoid Hardcoded Values**: Never hardcode sensitive values like passwords or API keys. Use external secret management services appropriate for the target cloud platform.
+
+---
+
+### Risk: Excessive Permissions (Least Privilege Violation)
+**Summary:** Granting more permissions than necessary to resources or identities increases the blast radius of a compromise across cloud platforms.
+**Mitigation Rule:** Define IAM roles, policies, and resource-based policies with the absolute minimum required permissions (least privilege). Use specific actions and resource ARNs where possible, avoiding wildcards like `*` for actions or resources in production environments.
+
+### Risk: Unrestricted Network Access
+**Summary:** Allowing unrestricted ingress or egress network traffic exposes resources to external threats and unauthorized access across cloud platforms.
+**Mitigation Rule:** Configure security groups, network ACLs, and firewall rules to strictly limit inbound and outbound network access to only necessary ports and IP ranges. Prioritize internal VPC communication and specific trusted sources. Avoid `0.0.0.0/0` unless explicitly required and thoroughly documented for a specific, secure purpose.
+
+### Risk: Publicly Accessible Storage
+**Summary:** Misconfigured storage buckets or blobs with public read/write access can lead to data exposure, exfiltration, or unauthorized data modification across cloud platforms.
+**Mitigation Rule:** Ensure all storage buckets (e.g., S3, Azure Blob, GCP Cloud Storage) are private by default. Implement public access blocks and deny public access policies. Restrict access to authenticated users or specific VPC endpoints.
+
+### Risk: Unencrypted Data at Rest
+**Summary:** Storing sensitive data without encryption at rest exposes it to compromise if storage resources are accessed by unauthorized entities across cloud platforms.
+**Mitigation Rule:** Enable encryption at rest for all storage services (e.g., S3, EBS, RDS, DynamoDB, EFS, Lambda environment variables, Azure Disks, GCP Persistent Disks) using cloud-managed keys (CMK) or customer-managed keys (CMK) where appropriate.
+
+### Risk: Missing Logging and Monitoring
+**Summary:** Inadequate logging and monitoring prevents timely detection of security incidents, unauthorized activities, and compliance violations across cloud platforms.
+**Mitigation Rule:** Enable comprehensive logging (e.g., CloudTrail, CloudWatch Logs, VPC Flow Logs, AWS Config, Azure Monitor, GCP Cloud Logging) for all resources. Configure centralized log storage, integrity checks, and alarms for critical security events.
+
+### Risk: Hardcoded Secrets
+**Summary:** Embedding sensitive credentials directly in configuration files poses a severe security risk, leading to compromise if the code is exposed across cloud platforms.
+**Mitigation Rule:** Never hardcode sensitive values. Always retrieve secrets (e.g., API keys, database credentials) from cloud-native secret management services (e.g., AWS Secrets Manager, AWS Systems Manager Parameter Store, Azure Key Vault, GCP Secret Manager) at runtime.
+
+### Risk: Lack of Resource Deletion Protection
+**Summary:** Accidental or malicious deletion of critical infrastructure resources can lead to severe service disruption and data loss across cloud platforms.
+**Mitigation Rule:** Apply a `DeletionPolicy` of `Retain` or `Snapshot` to critical Cloudformation resources (e.g., databases, S3 buckets, EC2 instances, EFS file systems) to prevent accidental data loss or service disruption upon stack deletion.
+
+### Risk: Weak HTTPS/TLS Enforcement
+**Summary:** Failure to enforce secure communication protocols (HTTPS/TLS) for data in transit exposes sensitive information to eavesdropping and tampering across cloud platforms.
+**Mitigation Rule:** Configure all public-facing endpoints (e.g., Load Balancers, API Gateways, CDN distributions, S3 buckets) to strictly enforce HTTPS/TLS 1.2 or higher. Redirect all HTTP traffic to HTTPS and avoid unencrypted protocols.
+
+### Risk: Unsecured Compute Configuration
+**Summary:** Default or insecure configurations for compute resources (e.g., Lambda functions, EC2 instances, containers) can introduce vulnerabilities and lead to compromise across cloud platforms.
+**Mitigation Rule:** Configure compute resources securely by default. This includes restricting network access for Lambda functions to a VPC, assigning least-privilege IAM roles to instances/functions, ensuring encrypted storage for temporary data, and avoiding unnecessary public IP assignments.


### PR DESCRIPTION
This pull request proposes adding support for infrastructure-as-code security rules. The current prompt is too focused on software vulnerabilities, so I’ve added a new prompt that follows the same format but targets cloud-security issues.

I’ve generated rules for both Terraform and CloudFormation, and I ran a test to confirm that when Terraform code is requested, it adds a security focus.

> **Scope note:** If you’d rather keep this repository limited to software-vulnerability rules, no worries, feel free to close this PR.

### Updates to IaC Rule Generation:

* [`generate_rules.py`](diffhunk://#diff-3a0d24ff7dfb35a745d517809a8468adbb40290a9aaa4a0fab0b5a7d3f294f91R15-R18): Added logic to identify infrastructure languages (`hcl`, `yaml`) and generate specialized security prompts for infrastructure-as-code scenarios. These prompts emphasize cloud security best practices.

### Minor Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16): Updated the description of `generate_rules.py` to note its dependency on the `GOOGLE_API_KEY` environment variable.